### PR TITLE
fix bug of reading version string from file version

### DIFF
--- a/src/main/java/build/tools/tzdb/TzdbZoneRulesCompiler.java
+++ b/src/main/java/build/tools/tzdb/TzdbZoneRulesCompiler.java
@@ -177,8 +177,8 @@ public final class TzdbZoneRulesCompiler {
             if (m.find()) {
                 version = m.group("ver");
             } else {
+                System.err.println("Source directory does not contain file: version");
                 System.exit(1);
-                System.err.println("Source directory does not contain file: VERSION");
             }
             printVerbose("Compiling TZDB version " + version);
             // parse source files

--- a/src/main/java/build/tools/tzdb/TzdbZoneRulesCompiler.java
+++ b/src/main/java/build/tools/tzdb/TzdbZoneRulesCompiler.java
@@ -171,8 +171,8 @@ public final class TzdbZoneRulesCompiler {
         }
         try {
             // get tzdb source version
-            Matcher m = Pattern.compile("tzdata(?<ver>[0-9]{4}[A-z])")
-                               .matcher(new String(Files.readAllBytes(srcDir.resolve("VERSION")),
+            Matcher m = Pattern.compile("(?<ver>[0-9]{4}[A-z])")
+                               .matcher(new String(Files.readAllBytes(srcDir.resolve("version")),
                                                    "ISO-8859-1"));
             if (m.find()) {
                 version = m.group("ver");


### PR DESCRIPTION
IANA Time Zone Database tarball container file `version`(NOT `VERSION`) since `tzdata2016h.tar.gz` with content in format `[0-9]{4}[A-z](?:-rearguard)*`(NOT begin with `tzdata`)